### PR TITLE
Version discovery fallback

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -172,9 +172,9 @@ impl ServiceInfo {
                 })
                 .and_then(|root| ServiceInfo::from_root(root, service))
                 .or_else(move |e| {
-                    if e.kind() == ErrorKind::ResourceNotFound {
+                    if e.kind() == ErrorKind::EndpointNotFound {
                         debug!(
-                            "Service returned ResourceNotFound when attempting version discovery, using {}",
+                            "Service returned EndpointNotFound when attempting version discovery, using {}",
                             fallback.root_url
                         );
                         future::Either::B(future::ok(fallback))


### PR DESCRIPTION
Hi,

I'm running against an OpenStack version that doesn't support version discovery - the Compute endpoint URL returned in the service catalog looks like `http://1.2.3.4/v2.1/abcdef`, and GETing that URL gives a 404, but `http://1.2.3.4/v2.1/abcdef/servers` works.

`openstack server list` skips the first GET and goes straight to the second, but rust-openstack master  fails with an EndpointNotFound error.

This avoids that, by spotting the error and falling back to the same behaviour as if `service.version_discovery_supported()` is false.