### PR TITLE
Use rustls instead of native-tls to avoid non-Rust dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ dirs = "^1.0"
 futures = "^0.1"
 log = "^0.4"
 osproto = "^0.1.0"
-reqwest = "^0.9.19"
+reqwest = { version = "^0.9", default-features = false, features = ["rustls-tls"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_yaml = "^0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,11 @@ edition = "2018"
 
 [features]
 
-default = ["sync"]
+default = ["sync", "native-tls"]
 sync = ["tokio"]
+native-tls = ["reqwest/default-tls"]
+rustls = ["reqwest/rustls-tls"]
+
 
 [dependencies]
 
@@ -25,7 +28,7 @@ dirs = "^1.0"
 futures = "^0.1"
 log = "^0.4"
 osproto = "^0.1.0"
-reqwest = { version = "^0.9", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "^0.9", default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_yaml = "^0.8"


### PR DESCRIPTION
Counterpart to https://github.com/dtantsur/rust-openstack/pull/96/files