### PR TITLE
feat(identity): enable project scope to take id or name

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,7 @@ use serde_yaml;
 use super::identity::Password;
 use super::{Error, ErrorKind, Session};
 
-use osproto::identity::IdOrName;
+use crate::identity::IdOrName;
 
 #[derive(Debug, Deserialize)]
 struct Auth {

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,8 @@ use serde_yaml;
 use super::identity::Password;
 use super::{Error, ErrorKind, Session};
 
+use osproto::identity::IdOrName;
+
 #[derive(Debug, Deserialize)]
 struct Auth {
     auth_url: String,
@@ -120,7 +122,7 @@ pub fn from_config<S: AsRef<str>>(cloud_name: S) -> Result<Session, Error> {
         .unwrap_or_else(|| String::from("Default"));
     let mut id = Password::new(&auth.auth_url, auth.username, auth.password, user_domain)?;
     if let Some(project_name) = auth.project_name {
-        id.set_project_scope(project_name, project_domain);
+        id.set_project_scope(IdOrName::Name(project_name), IdOrName::Name(project_domain));
     }
     if let Some(region) = cloud.region_name {
         id.set_region(region)
@@ -149,11 +151,16 @@ pub fn from_env() -> Result<Session, Error> {
 
         let id = Password::new(&auth_url, user_name, password, user_domain)?;
 
-        let project_name = _get_env("OS_PROJECT_NAME")?;
-        let project_domain =
-            env::var("OS_PROJECT_DOMAIN_NAME").unwrap_or_else(|_| String::from("Default"));
+        let project = _get_env("OS_PROJECT_ID")
+            .map(IdOrName::Id)
+            .or_else(|_| _get_env("OS_PROJECT_NAME").map(IdOrName::Name))?;
 
-        let mut session = Session::new(id.with_project_scope(project_name, project_domain));
+        let project_domain = _get_env("OS_PROJECT_DOMAIN_ID")
+            .map(IdOrName::Id)
+            .or_else(|_| _get_env("OS_PROJECT_DOMAIN_NAME").map(IdOrName::Name))
+            .ok();
+
+        let mut session = Session::new(id.with_project_scope(project, project_domain));
 
         if let Ok(interface) = env::var("OS_INTERFACE") {
             session.set_endpoint_interface(interface)

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -83,6 +83,7 @@ pub trait Identity {
 /// with [with_project_scope](#method.with_project_scope):
 ///
 /// ```rust,no_run
+/// # use osproto::identity::IdOrName;
 /// let auth = osauth::identity::Password::new(
 ///     "https://cloud.local/identity",
 ///     "admin",
@@ -90,7 +91,7 @@ pub trait Identity {
 ///     "Default"
 /// )
 /// .expect("Invalid auth_url")
-/// .with_project_scope("project1", "Default");
+/// .with_project_scope(IdOrName::Name("project1".to_string()), None);
 ///
 /// let session = osauth::Session::new(auth);
 /// ```
@@ -98,6 +99,7 @@ pub trait Identity {
 /// If your cloud has several regions, pick one using [with_region](#method.with_region):
 ///
 /// ```rust,no_run
+/// # use osproto::identity::IdOrName;
 /// let auth = osauth::identity::Password::new(
 ///     "https://cloud.local/identity",
 ///     "admin",
@@ -105,7 +107,7 @@ pub trait Identity {
 ///     "Default"
 /// )
 /// .expect("Invalid auth_url")
-/// .with_project_scope("project1", "Default")
+/// .with_project_scope(IdOrName::Name("project1".to_string()), None)
 /// .with_region("US-East");
 ///
 /// let session = osauth::Session::new(auth);
@@ -116,6 +118,7 @@ pub trait Identity {
 /// [with_default_endpoint_interface](#method.with_default_endpoint_interface).
 ///
 /// ```rust,no_run
+/// # use osproto::identity::IdOrName;
 /// let auth = osauth::identity::Password::new(
 ///     "https://cloud.local/identity",
 ///     "admin",
@@ -123,7 +126,7 @@ pub trait Identity {
 ///     "Default"
 /// )
 /// .expect("Invalid auth_url")
-/// .with_project_scope("project1", "Default")
+/// .with_project_scope(IdOrName::Name("project1".to_string()), None)
 /// .with_default_endpoint_interface("internal");
 /// ```
 ///
@@ -237,14 +240,10 @@ impl Password {
     /// Scope authentication to the given project.
     ///
     /// This is required in the most cases.
-    pub fn set_project_scope<S1, S2>(&mut self, project_name: S1, project_domain_name: S2)
-    where
-        S1: Into<String>,
-        S2: Into<String>,
-    {
+    pub fn set_project_scope(&mut self, project: IdOrName, domain: impl Into<Option<IdOrName>>) {
         self.body.auth.scope = Some(protocol::Scope::Project(protocol::Project {
-            project: protocol::IdOrName::Name(project_name.into()),
-            domain: Some(protocol::IdOrName::Name(project_domain_name.into())),
+            project,
+            domain: domain.into(),
         }));
     }
 
@@ -260,16 +259,12 @@ impl Password {
 
     /// Scope authentication to the given project.
     #[inline]
-    pub fn with_project_scope<S1, S2>(
+    pub fn with_project_scope(
         mut self,
-        project_name: S1,
-        project_domain_name: S2,
-    ) -> Password
-    where
-        S1: Into<String>,
-        S2: Into<String>,
-    {
-        self.set_project_scope(project_name, project_domain_name);
+        project: IdOrName,
+        domain: impl Into<Option<IdOrName>>,
+    ) -> Password {
+        self.set_project_scope(project, domain);
         self
     }
 
@@ -473,7 +468,10 @@ pub mod test {
             "example.com",
         )
         .unwrap()
-        .with_project_scope("cool project", "example.com");
+        .with_project_scope(
+            IdOrName::Name("cool project".to_string()),
+            IdOrName::Name("example.com".to_string()),
+        );
         assert_eq!(id.auth_url().to_string(), "http://127.0.0.1:8080/identity");
         assert_eq!(id.user(), &IdOrName::Name("user".to_string()));
         assert_eq!(

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -83,7 +83,7 @@ pub trait Identity {
 /// with [with_project_scope](#method.with_project_scope):
 ///
 /// ```rust,no_run
-/// # use osproto::identity::IdOrName;
+/// # use osauth::identity::IdOrName;
 /// let auth = osauth::identity::Password::new(
 ///     "https://cloud.local/identity",
 ///     "admin",
@@ -99,7 +99,7 @@ pub trait Identity {
 /// If your cloud has several regions, pick one using [with_region](#method.with_region):
 ///
 /// ```rust,no_run
-/// # use osproto::identity::IdOrName;
+/// # use osauth::identity::IdOrName;
 /// let auth = osauth::identity::Password::new(
 ///     "https://cloud.local/identity",
 ///     "admin",
@@ -118,7 +118,7 @@ pub trait Identity {
 /// [with_default_endpoint_interface](#method.with_default_endpoint_interface).
 ///
 /// ```rust,no_run
-/// # use osproto::identity::IdOrName;
+/// # use osauth::identity::IdOrName;
 /// let auth = osauth::identity::Password::new(
 ///     "https://cloud.local/identity",
 ///     "admin",


### PR DESCRIPTION
`from_env` now prefers id over name for both project and project domain.
To do this we had to change the signature of the setter functions for
the project scope.

The reason for this change is that our openstack server did not accept
just the project name and domain, but rather needed us to send the
project id and corresponding project domain id.

BREAKING_CHANGE: `with_project_scope` and `set_project_scope` now takes
`IdOrName` instead of string which is turned into a name.