### PR TITLE
feat: Add support for clouds-public.yaml and secure.yaml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { version = "^0.2.0", features = ["macros", "sync"] }
 [dev-dependencies]
 
 env_logger = "^0.7"
+tempfile = "3.1.0"
 
 [lib]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tokio = { version = "^0.2.0", features = ["macros", "sync"] }
 
 env_logger = "^0.7"
 tempfile = "3.1.0"
+lazy_static = "1.4.0"
 
 [lib]
 

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -50,7 +50,7 @@ impl<Srv> Adapter<Srv> {
         Adapter::from_session(Session::new(auth_type), service)
     }
 
-    /// Create a new adapter from a `clouds.yaml` configuration file.
+    /// Create a new adapter from `clouds.yaml`, `clouds-public.yaml` and `secure.yaml` configuration files.
     #[inline]
     pub fn from_config<S: AsRef<str>>(cloud_name: S, service: Srv) -> Result<Adapter<Srv>, Error> {
         Ok(config::from_config(cloud_name)?.into_adapter(service))

--- a/src/config.rs
+++ b/src/config.rs
@@ -314,12 +314,13 @@ pub mod test {
     use super::merge_mappings;
     use super::*;
     use env::set_current_dir;
+    use std::error::Error;
     use std::fs::File;
     use std::io::Write;
     use tempfile::tempdir;
 
     #[test]
-    fn test_from_config() {
+    fn test_from_config() -> Result<(), Box<dyn Error>> {
         let dir = tempdir().unwrap();
 
         let clouds_file_path = dir.path().join("clouds.yaml");
@@ -358,17 +359,20 @@ pub mod test {
 
         set_current_dir(&dir).unwrap();
 
-        assert!(from_config("cloud_name").is_ok());
+        // Here is the test
+        let _ = from_config("cloud_name")?;
 
         drop(clouds_file);
         drop(clouds_public_file);
         drop(secure_file);
 
         dir.close().unwrap();
+
+        Ok(())
     }
 
     #[test]
-    fn test_from_config_clouds_yaml_only() {
+    fn test_from_config_clouds_yaml_only() -> Result<(), Box<dyn Error>> {
         let dir = tempdir().unwrap();
 
         let clouds_file_path = dir.path().join("clouds.yaml");
@@ -387,10 +391,13 @@ pub mod test {
 
         set_current_dir(&dir).unwrap();
 
-        assert!(from_config("cloud_name").is_ok());
+        // This is the test
+        let _ = from_config("cloud_name")?;
 
         drop(clouds_file);
         dir.close().unwrap();
+
+        Ok(())
     }
 
     #[test]
@@ -582,8 +589,8 @@ public-clouds:
 
     #[test]
     fn test_find_config_fail() {
-        let found = find_config("shouldnt_exist");
-        assert!(found.is_none());
+        let config = find_config("shouldnt_exist");
+        assert_eq!(config, None);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -228,14 +228,7 @@ pub fn from_config<S: AsRef<str>>(cloud_name: S) -> Result<Session, Error> {
         })?,
     )?;
 
-    let clouds_string = serde_yaml::to_string(&clouds).map_err(|e| {
-        Error::new(
-            ErrorKind::InvalidConfig,
-            format!("Failed to convert yaml to String: {}", e),
-        )
-    })?;
-
-    let mut clouds_root: Root = serde_yaml::from_str(&clouds_string).map_err(|e| {
+    let mut clouds_root: Root = serde_yaml::from_value(clouds).map_err(|e| {
         Error::new(
             ErrorKind::InvalidConfig,
             format!("Cannot parse clouds.yaml: {}", e),

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@
 
 use std::collections::HashMap;
 use std::env;
-use std::fs::File;
+use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -61,8 +61,96 @@ struct Root {
     clouds: Clouds,
 }
 
-fn find_config() -> Option<PathBuf> {
-    let current = Path::new("./clouds.yaml");
+/// Merge two nested serde_yaml::Mapping structs
+/// The values from src are merged into dest. Values in src override values in dest.
+fn merge_mappings(src: &serde_yaml::Mapping, dest: &mut serde_yaml::Mapping) {
+    for (src_key, src_value) in src.iter() {
+        if src_value.is_mapping()
+            && dest.contains_key(src_key)
+            && dest.get(src_key).unwrap().is_mapping()
+        {
+            merge_mappings(
+                src_value.as_mapping().unwrap(),
+                dest.get_mut(src_key).unwrap().as_mapping_mut().unwrap(),
+            );
+        } else {
+            match dest.insert(src_key.to_owned(), src_value.to_owned()) {
+                // Ignore the Option returned
+                _ => {}
+            }
+        }
+    }
+}
+
+// Inject profiles from clouds-public.yaml into clouds.yaml and return it in a new Value
+fn inject_profiles(
+    clouds_public: &serde_yaml::Mapping,
+    clouds: &serde_yaml::Mapping,
+) -> Result<serde_yaml::Value, Error> {
+    let mut temp_mapping = serde_yaml::Mapping::new();
+    match temp_mapping.insert(
+        "clouds".into(),
+        serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+    ) {
+        _ => {} // ignore returned Option
+    };
+
+    let clouds_mapping = clouds.get(&"clouds".into());
+    let clouds_public_mapping = clouds_public.get(&"public-clouds".into());
+
+    if clouds_mapping.is_some()
+        && clouds_mapping.unwrap().is_mapping()
+        && clouds_public_mapping.is_some()
+        && clouds_public_mapping.unwrap().is_mapping()
+    {
+        for (cloud_name, cloud) in clouds_mapping.unwrap().as_mapping().unwrap().iter() {
+            if let Some(cloud_map) = cloud.as_mapping() {
+                if let Some(profile) = cloud_map.get(&"profile".into()) {
+                    if clouds_public_mapping
+                        .unwrap()
+                        .as_mapping()
+                        .unwrap()
+                        .get(profile)
+                        .is_none()
+                    {
+                        return Err(Error::new(
+                            ErrorKind::InvalidConfig,
+                            format!(
+                                "Missing profile {} in clouds-public.yaml.",
+                                profile.as_str().unwrap()
+                            ),
+                        ));
+                    } else {
+                        match temp_mapping
+                            .get_mut(&"clouds".into())
+                            .unwrap()
+                            .as_mapping_mut()
+                            .unwrap()
+                            .insert(
+                                cloud_name.to_owned(),
+                                clouds_public_mapping
+                                    .unwrap()
+                                    .as_mapping()
+                                    .unwrap()
+                                    .get(profile)
+                                    .unwrap()
+                                    .to_owned(),
+                            ) {
+                            _ => {} // ignore returned Option
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    merge_mappings(clouds, &mut temp_mapping);
+    Ok(serde_yaml::Value::Mapping(temp_mapping))
+}
+
+fn find_config<S: AsRef<str>>(filename: S) -> Option<PathBuf> {
+    let filename = filename.as_ref();
+    let current = Path::new(filename);
     if current.is_file() {
         match current.canonicalize() {
             Ok(val) => return Some(val),
@@ -71,7 +159,7 @@ fn find_config() -> Option<PathBuf> {
     }
 
     if let Some(mut home) = dirs::home_dir() {
-        home.push(".config/openstack/clouds.yaml");
+        home.push(format!(".config/openstack/{}", filename));
         if home.is_file() {
             return Some(home);
         }
@@ -79,7 +167,7 @@ fn find_config() -> Option<PathBuf> {
         warn!("Cannot find home directory");
     }
 
-    let abs = PathBuf::from("/etc/openstack/clouds.yaml");
+    let abs = PathBuf::from(format!("/etc/openstack/{}", filename));
     if abs.is_file() {
         Some(abs)
     } else {
@@ -87,26 +175,92 @@ fn find_config() -> Option<PathBuf> {
     }
 }
 
+fn read_config_file(filename: &str) -> Result<String, Error> {
+    let path = find_config(filename).ok_or_else(|| {
+        Error::new(
+            ErrorKind::InvalidConfig,
+            format!("{} was not found in any location", filename),
+        )
+    })?;
+
+    read_to_string(path).map_err(|e| {
+        Error::new(
+            ErrorKind::InvalidConfig,
+            format!("Cannot read {}: {}", filename, e),
+        )
+    })
+}
+
 /// Create a `Session` from the config file.
 pub fn from_config<S: AsRef<str>>(cloud_name: S) -> Result<Session, Error> {
-    let path = find_config().ok_or_else(|| {
+    let mut clouds: serde_yaml::Value = serde_yaml::from_str(&read_config_file("clouds.yaml")?)
+        .map_err(|e| {
+            Error::new(
+                ErrorKind::InvalidConfig,
+                format!("Cannot parse clouds.yaml: {}", e),
+            )
+        })?;
+
+    let clouds_public: serde_yaml::Value = serde_yaml::from_str(
+        // If clouds-public.yaml is missing, let's pretend that it's there but empty.
+        &read_config_file("clouds-public.yaml").unwrap_or_else(|_| String::from("---\n{}\n")),
+    )
+    .map_err(|e| {
         Error::new(
             ErrorKind::InvalidConfig,
-            "clouds.yaml was not found in any location",
+            format!("Cannot parse clouds-public.yaml: {}", e),
         )
     })?;
-    let file = File::open(path).map_err(|e| {
+
+    let secure: serde_yaml::Value = serde_yaml::from_str(
+        // If secure.yaml is missing, let's pretend that it's there but empty.
+        &read_config_file("secure.yaml").unwrap_or_else(|_| String::from("---\n{}\n")),
+    )
+    .map_err(|e| {
         Error::new(
             ErrorKind::InvalidConfig,
-            format!("Cannot read config.yaml: {}", e),
+            format!("Cannot parse secure.yaml: {}", e),
         )
     })?;
-    let mut clouds_root: Root = serde_yaml::from_reader(file).map_err(|e| {
-        Error::new(
-            ErrorKind::InvalidConfig,
-            format!("Cannot parse clouds.yaml: {}", e),
-        )
-    })?;
+
+    merge_mappings(
+        secure.as_mapping().ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidConfig,
+                format!("secure.yaml's root is not a Mapping"),
+            )
+        })?,
+        clouds.as_mapping_mut().ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidConfig,
+                format!("clouds.yaml's root is not a Mapping"),
+            )
+        })?,
+    );
+
+    clouds = inject_profiles(
+        clouds_public.as_mapping().ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidConfig,
+                format!("clouds-public.yaml's root is not a Mapping"),
+            )
+        })?,
+        clouds.as_mapping_mut().ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidConfig,
+                format!("clouds.yaml's root is not a Mapping"),
+            )
+        })?,
+    )
+    .unwrap();
+
+    let mut clouds_root: Root =
+        serde_yaml::from_str(serde_yaml::to_string(&clouds).unwrap().as_str()).map_err(|e| {
+            Error::new(
+                ErrorKind::InvalidConfig,
+                format!("Cannot parse clouds.yaml: {}", e),
+            )
+        })?;
 
     let name = cloud_name.as_ref();
     let cloud =
@@ -179,5 +333,372 @@ pub fn from_env() -> Result<Session, Error> {
         *session.endpoint_filters_mut() = filters;
 
         Ok(session)
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::merge_mappings;
+    use super::*;
+    use env::set_current_dir;
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_from_config() {
+        let dir = tempdir().unwrap();
+
+        let clouds_file_path = dir.path().join("clouds.yaml");
+        let mut clouds_file = File::create(&clouds_file_path).unwrap();
+        write!(
+            clouds_file,
+            r#"clouds:
+  cloud_name:
+    auth:
+      auth_url: http://url1
+      username: user1
+    profile: test_profile"#
+        )
+        .unwrap();
+
+        let clouds_public_file_path = dir.path().join("clouds-public.yaml");
+        let mut clouds_public_file = File::create(&clouds_public_file_path).unwrap();
+        write!(
+            clouds_public_file,
+            r#"public-clouds:
+  test_profile:
+    region_name: region1"#
+        )
+        .unwrap();
+
+        let secure_file_path = dir.path().join("secure.yaml");
+        let mut secure_file = File::create(&secure_file_path).unwrap();
+        write!(
+            secure_file,
+            r#"clouds:
+  cloud_name:
+    auth:
+      password: password1"#
+        )
+        .unwrap();
+
+        set_current_dir(&dir).unwrap();
+
+        assert!(from_config("cloud_name").is_ok());
+
+        drop(clouds_file);
+        drop(clouds_public_file);
+        drop(secure_file);
+
+        dir.close().unwrap();
+    }
+
+    #[test]
+    fn test_from_config_clouds_yaml_only() {
+        let dir = tempdir().unwrap();
+
+        let clouds_file_path = dir.path().join("clouds.yaml");
+        let mut clouds_file = File::create(&clouds_file_path).unwrap();
+        write!(
+            clouds_file,
+            r#"clouds:
+  cloud_name:
+    auth:
+      auth_url: http://url1
+      username: user1
+      password: password1
+    region_name: region1"#
+        )
+        .unwrap();
+
+        set_current_dir(&dir).unwrap();
+
+        assert!(from_config("cloud_name").is_ok());
+
+        drop(clouds_file);
+        dir.close().unwrap();
+    }
+
+    #[test]
+    fn test_inject_profiles_error() {
+        let clouds_data: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+clouds:
+  cloud_name:
+    auth:
+      username: user1
+      password: password1
+    profile: test_profile"#,
+        )
+        .unwrap();
+
+        let clouds_public_data: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+public-clouds:
+  test_profile_other:
+    auth:
+        username: user2
+        auth_url: url2
+    region_name: region2"#,
+        )
+        .unwrap();
+
+        let err = inject_profiles(
+            clouds_public_data.as_mapping().unwrap(),
+            clouds_data.as_mapping().unwrap(),
+        );
+        assert_eq!(ErrorKind::InvalidConfig, err.as_ref().unwrap_err().kind());
+        assert_eq!("configuration file cannot be found or is invalid: Missing profile test_profile in clouds-public.yaml.", format!("{}", err.unwrap_err()));
+    }
+
+    #[test]
+    fn test_inject_profiles_ok() {
+        let clouds_data: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+clouds:
+  cloud_name:
+    auth:
+      username: user1
+      password: password1
+    profile: test_profile"#,
+        )
+        .unwrap();
+
+        let clouds_public_data: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+public-clouds:
+  test_profile:
+    auth:
+        username: user2
+        auth_url: url2
+    region_name: region2"#,
+        )
+        .unwrap();
+
+        let actual = inject_profiles(
+            clouds_public_data.as_mapping().unwrap(),
+            clouds_data.as_mapping().unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            "region2",
+            actual
+                .as_mapping()
+                .unwrap()
+                .get(&"clouds".into())
+                .unwrap()
+                .as_mapping()
+                .unwrap()
+                .get(&"cloud_name".into())
+                .unwrap()
+                .as_mapping()
+                .unwrap()
+                .get(&"region_name".into())
+                .unwrap()
+        );
+
+        assert_eq!(
+            "user1",
+            actual
+                .as_mapping()
+                .unwrap()
+                .get(&"clouds".into())
+                .unwrap()
+                .as_mapping()
+                .unwrap()
+                .get(&"cloud_name".into())
+                .unwrap()
+                .as_mapping()
+                .unwrap()
+                .get(&"auth".into())
+                .unwrap()
+                .as_mapping()
+                .unwrap()
+                .get(&"username".into())
+                .unwrap()
+        );
+
+        assert_eq!(
+            "password1",
+            actual
+                .as_mapping()
+                .unwrap()
+                .get(&"clouds".into())
+                .unwrap()
+                .as_mapping()
+                .unwrap()
+                .get(&"cloud_name".into())
+                .unwrap()
+                .as_mapping()
+                .unwrap()
+                .get(&"auth".into())
+                .unwrap()
+                .as_mapping()
+                .unwrap()
+                .get(&"password".into())
+                .unwrap()
+        );
+
+        assert_eq!(
+            "url2",
+            actual
+                .as_mapping()
+                .unwrap()
+                .get(&"clouds".into())
+                .unwrap()
+                .as_mapping()
+                .unwrap()
+                .get(&"cloud_name".into())
+                .unwrap()
+                .as_mapping()
+                .unwrap()
+                .get(&"auth".into())
+                .unwrap()
+                .as_mapping()
+                .unwrap()
+                .get(&"auth_url".into())
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_read_config_file_error() {
+        let result = read_config_file("doesnt_exist");
+
+        match result {
+            Err(e) => { assert_eq!("configuration file cannot be found or is invalid: doesnt_exist was not found in any location", e.to_string())
+            }
+            Ok(_) => { panic!("Result was unexpectedly Ok") }
+        }
+    }
+
+    #[test]
+    fn test_read_config_file_success() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("test_read_config_file_success");
+        let mut file = File::create(&file_path).unwrap();
+        write!(file, "test data").unwrap();
+
+        set_current_dir(&dir).unwrap();
+
+        let actual = read_config_file("test_read_config_file_success").unwrap();
+
+        assert_eq!("test data", actual);
+
+        drop(file);
+        dir.close().unwrap();
+    }
+
+    #[test]
+    fn test_find_config_success() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("test_find_config_success");
+        let file = File::create(&file_path).unwrap();
+
+        set_current_dir(&dir).unwrap();
+
+        let found = find_config("test_find_config_success").unwrap();
+
+        assert_eq!(file_path, found);
+
+        drop(file);
+        dir.close().unwrap();
+    }
+
+    #[test]
+    fn test_find_config_fail() {
+        let found = find_config("shouldnt_exist");
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_merge_clouds() {
+        let src_clouds_data = r#"
+clouds:
+  cloud_name:
+    auth:
+      username: user2
+      password: password1
+    region_name: region2"#;
+
+        let dest_clouds_data = r#"
+clouds:
+  cloud_name:
+    auth:
+      username: user1
+      project_name: project1
+      user_domain_name: domain1
+      project_domain_name: domain1
+      auth_url: "url1"
+    region_name: region1"#;
+
+        let src: serde_yaml::Value = serde_yaml::from_str(src_clouds_data).unwrap();
+        let mut dest: serde_yaml::Value = serde_yaml::from_str(dest_clouds_data).unwrap();
+        merge_mappings(&src.as_mapping().unwrap(), dest.as_mapping_mut().unwrap());
+
+        let dest_cloud = dest
+            .get("clouds")
+            .unwrap()
+            .as_mapping()
+            .unwrap()
+            .get(&"cloud_name".into())
+            .unwrap()
+            .to_owned();
+
+        assert_eq!(
+            &serde_yaml::Value::String("region2".into()),
+            dest_cloud.get("region_name").unwrap()
+        );
+
+        let dest_auth = dest_cloud
+            .get("auth")
+            .unwrap()
+            .as_mapping()
+            .unwrap()
+            .to_owned();
+
+        assert_eq!(
+            "user2",
+            dest_auth.get(&"username".into()).unwrap().as_str().unwrap()
+        );
+
+        assert_eq!(
+            "password1",
+            dest_auth.get(&"password".into()).unwrap().as_str().unwrap()
+        );
+
+        assert_eq!(
+            "project1",
+            dest_auth
+                .get(&"project_name".into())
+                .unwrap()
+                .as_str()
+                .unwrap()
+        );
+
+        assert_eq!(
+            "domain1",
+            dest_auth
+                .get(&"project_domain_name".into())
+                .unwrap()
+                .as_str()
+                .unwrap()
+        );
+
+        assert_eq!(
+            "domain1",
+            dest_auth
+                .get(&"user_domain_name".into())
+                .unwrap()
+                .as_str()
+                .unwrap()
+        );
+
+        assert_eq!(
+            "url1",
+            dest_auth.get(&"auth_url".into()).unwrap().as_str().unwrap()
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -202,13 +202,13 @@ pub fn from_config<S: AsRef<str>>(cloud_name: S) -> Result<Session, Error> {
         secure.as_mapping().ok_or_else(|| {
             Error::new(
                 ErrorKind::InvalidConfig,
-                format!("secure.yaml's root is not a Mapping"),
+                "secure.yaml's root is not a Mapping".to_string(),
             )
         })?,
         clouds.as_mapping_mut().ok_or_else(|| {
             Error::new(
                 ErrorKind::InvalidConfig,
-                format!("clouds.yaml's root is not a Mapping"),
+                "clouds.yaml's root is not a Mapping".to_string(),
             )
         })?,
     );
@@ -217,13 +217,13 @@ pub fn from_config<S: AsRef<str>>(cloud_name: S) -> Result<Session, Error> {
         clouds_public.as_mapping().ok_or_else(|| {
             Error::new(
                 ErrorKind::InvalidConfig,
-                format!("clouds-public.yaml's root is not a Mapping"),
+                "clouds-public.yaml's root is not a Mapping".to_string(),
             )
         })?,
         clouds.as_mapping_mut().ok_or_else(|| {
             Error::new(
                 ErrorKind::InvalidConfig,
-                format!("clouds.yaml's root is not a Mapping"),
+                "clouds.yaml's root is not a Mapping".to_string(),
             )
         })?,
     )?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -74,7 +74,7 @@ pub enum ErrorKind {
     /// Maps to HTTP 5xx codes.
     InternalServerError,
 
-    /// Invalid clouds.yaml file.
+    /// Invalid clouds.yaml, clouds-public.yaml or secure.yaml file.
     InvalidConfig,
 }
 
@@ -144,7 +144,7 @@ impl ErrorKind {
             ErrorKind::ProtocolError => "Error when accessing the server",
             ErrorKind::InvalidResponse => "Received invalid response",
             ErrorKind::InternalServerError => "Internal server error or bad gateway",
-            ErrorKind::InvalidConfig => "clouds.yaml cannot be found or is invalid",
+            ErrorKind::InvalidConfig => "configuration file cannot be found or is invalid",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //!   services without authentication.
 //!
 //! A `Session` can be created directly by loading it:
-//! * From the `clouds.yaml` configuration file using [from_config](fn.from_config.html).
+//! * From the `clouds.yaml`, `clouds-public.yaml` and `secure.yaml` configuration files using [from_config](fn.from_config.html).
 //! * From environment variables using [from_env](fn.from_env.html).
 //!
 //! See [Session](struct.Session.html) documentation for the details on using a `Session` for making


### PR DESCRIPTION
Before this change, only clouds.yaml was supported when getting a session
via `from_config`.

This change introduces support for clouds-public.yaml and secure.yaml.

It was not trivial to use serde_derive to parse the files individually
as all 3 files may contain all or none of the configuration, as long as
the merged result is valid configuration.
So the strategy here was to parse the 3 files into serde_yaml::Value
structs and merge them, and then convert them to the serde_derive
structs.