### PR TITLE
fix(config): read region from env (OS_REGION_NAME) when calling from_env

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -171,6 +171,11 @@ pub fn from_env() -> Result<Session, Error> {
         if let Ok(interface) = env::var("OS_INTERFACE") {
             filters.set_interfaces(InterfaceType::from_str(&interface)?);
         }
+
+        if let Ok(region) = env::var("OS_REGION_NAME") {
+            filters.region = Some(region);
+        }
+
         *session.endpoint_filters_mut() = filters;
 
         Ok(session)


### PR DESCRIPTION
The enviroment variable OS_REGION_NAME is not read when `from_env` is
used to create a session. This change fixes that.