### PR TITLE
fix: reduce the size of Password/Token from 416 to 304 bytes

### DIFF
--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -22,8 +22,6 @@ mod password;
 pub(crate) mod protocol;
 mod token;
 
-use reqwest::Url;
-
 use super::common::IdOrName;
 
 pub use self::password::Password;
@@ -47,10 +45,4 @@ pub enum Scope {
         /// ID or name of the project domain.
         domain: Option<IdOrName>,
     },
-}
-
-/// Generic trait for authentication using Identity API V3.
-pub trait Identity {
-    /// Get a reference to the auth URL.
-    fn auth_url(&self) -> &Url;
 }

--- a/src/identity/protocol.rs
+++ b/src/identity/protocol.rs
@@ -18,7 +18,7 @@ use chrono::{DateTime, FixedOffset};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize, Serializer};
 
-use crate::common::{IdAndName, IdOrName};
+use crate::common::IdOrName;
 
 /// User and password.
 #[derive(Clone, Debug, Serialize)]
@@ -103,7 +103,6 @@ pub struct CatalogRoot {
 /// An authentication token with embedded catalog.
 #[derive(Clone, Debug, Deserialize)]
 pub struct Token {
-    pub roles: Vec<IdAndName>,
     pub expires_at: DateTime<FixedOffset>,
     pub catalog: Vec<CatalogRecord>,
 }


### PR DESCRIPTION
BREAKING CHANGE
    Removes the Identity trait (that unlikely was used anyway).