### PR TITLE
feat(auth): make get_endpoint synchronous

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -40,13 +40,12 @@ pub trait AuthType: Debug + Sync + Send {
         request: RequestBuilder,
     ) -> Result<RequestBuilder, Error>;
 
-    /// Get a URL for the requested service using the provided client (if needed).
-    async fn get_endpoint(
-        &self,
-        client: &Client,
-        service_type: String,
-        filters: EndpointFilters,
-    ) -> Result<Url, Error>;
+    /// Get a URL for the requested service.
+    ///
+    /// When a service catalog is used, the URL is returned from cache, which means that `refresh`
+    /// *must* be called at least once before `get_endpoint`. Implementations may panic or return an
+    /// error if this condition is not met.
+    fn get_endpoint(&self, service_type: &str, filters: &EndpointFilters) -> Result<Url, Error>;
 
     /// Refresh the authentication (renew the token, etc).
     async fn refresh(&self, client: &Client) -> Result<(), Error>;
@@ -107,12 +106,7 @@ impl AuthType for NoAuth {
     }
 
     /// Get a predefined endpoint for all service types
-    async fn get_endpoint(
-        &self,
-        _client: &Client,
-        service_type: String,
-        _filters: EndpointFilters,
-    ) -> Result<Url, Error> {
+    fn get_endpoint(&self, service_type: &str, _filters: &EndpointFilters) -> Result<Url, Error> {
         self.endpoint.clone().ok_or_else(|| {
             Error::new(
                 ErrorKind::EndpointNotFound,
@@ -132,8 +126,6 @@ impl AuthType for NoAuth {
 
 #[cfg(test)]
 pub mod test {
-    use reqwest::Client;
-
     use super::{AuthType, NoAuth};
 
     #[test]
@@ -154,10 +146,7 @@ pub mod test {
     #[tokio::test]
     async fn test_noauth_get_endpoint() {
         let a = NoAuth::new("http://127.0.0.1:8080/v1").unwrap();
-        let e = a
-            .get_endpoint(&Client::new(), String::from("foobar"), Default::default())
-            .await
-            .unwrap();
+        let e = a.get_endpoint("foobar", &Default::default()).unwrap();
         assert_eq!(e.scheme(), "http");
         assert_eq!(e.host_str().unwrap(), "127.0.0.1");
         assert_eq!(e.port().unwrap(), 8080u16);

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -72,12 +72,7 @@ impl AuthType for BasicAuth {
     }
 
     /// Get a predefined endpoint for all service types
-    async fn get_endpoint(
-        &self,
-        _client: &Client,
-        _service_type: String,
-        _filters: EndpointFilters,
-    ) -> Result<Url, Error> {
+    fn get_endpoint(&self, _service_type: &str, _filters: &EndpointFilters) -> Result<Url, Error> {
         Ok(self.endpoint.clone())
     }
 

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -33,6 +33,10 @@ impl ServiceCatalog {
         ServiceCatalog { inner: catalog }
     }
 
+    pub(crate) fn empty() -> ServiceCatalog {
+        ServiceCatalog { inner: Vec::new() }
+    }
+
     /// Find an endpoint in the catalog.
     pub fn find_endpoint(
         &self,

--- a/src/client.rs
+++ b/src/client.rs
@@ -87,14 +87,12 @@ impl AuthenticatedClient {
 
     /// Get a URL for the requested service.
     #[inline]
-    pub async fn get_endpoint(
+    pub fn get_endpoint(
         &self,
-        service_type: String,
-        filters: EndpointFilters,
+        service_type: &str,
+        filters: &EndpointFilters,
     ) -> Result<Url, Error> {
-        self.auth
-            .get_endpoint(&self.client, service_type, filters)
-            .await
+        self.auth.get_endpoint(service_type, filters)
     }
 
     /// Get a reference to the inner (non-authenticated) client.

--- a/src/identity/internal.rs
+++ b/src/identity/internal.rs
@@ -14,15 +14,15 @@
 
 //! Internal implementation of the identity authentication.
 
-use std::collections::hash_map::DefaultHasher;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
+use std::{collections::hash_map::DefaultHasher, sync::RwLock};
 
 use chrono::{DateTime, Duration, FixedOffset, Local};
 use log::{debug, error, trace};
 use reqwest::{Client, Response, Url};
-use tokio::sync::{RwLock, RwLockReadGuard};
+use tokio::sync::{RwLock as AsyncRwLock, RwLockReadGuard};
 
 use super::protocol::{self, AuthRoot};
 use super::{IdOrName, Scope, INVALID_SUBJECT_HEADER, MISSING_SUBJECT_HEADER, TOKEN_MIN_VALIDITY};
@@ -35,7 +35,6 @@ use crate::{EndpointFilters, Error, ErrorKind};
 pub(crate) struct Token {
     value: String,
     expires_at: DateTime<FixedOffset>,
-    catalog: ServiceCatalog,
 }
 
 static_assertions::assert_eq_size!(Option<Token>, Token);
@@ -44,12 +43,10 @@ impl fmt::Debug for Token {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut hasher = DefaultHasher::new();
         self.value.hash(&mut hasher);
-        write!(
-            f,
-            "Token {{ value: hash({}), catalog: {:?} }}",
-            hasher.finish(),
-            self.catalog
-        )
+        f.debug_struct("Token")
+            .field("hash(value)", &hasher.finish())
+            .field("expires_at", &self.expires_at)
+            .finish()
     }
 }
 
@@ -58,7 +55,8 @@ impl fmt::Debug for Token {
 pub(crate) struct Internal {
     body: AuthRoot,
     token_endpoint: String,
-    cached_token: RwLock<Option<Token>>,
+    cached_token: AsyncRwLock<Option<Token>>,
+    catalog: RwLock<ServiceCatalog>,
 }
 
 impl Internal {
@@ -82,7 +80,8 @@ impl Internal {
         Ok(Internal {
             body,
             token_endpoint,
-            cached_token: RwLock::new(None),
+            cached_token: AsyncRwLock::new(None),
+            catalog: RwLock::new(ServiceCatalog::empty()),
         })
     }
 
@@ -95,18 +94,13 @@ impl Internal {
     }
 
     /// Get a URL for the requested service.
-    pub async fn get_endpoint(
+    pub fn get_endpoint(
         &self,
-        client: &Client,
-        service_type: String,
-        filters: EndpointFilters,
+        service_type: &str,
+        filters: &EndpointFilters,
     ) -> Result<Url, Error> {
-        debug!(
-            "Requesting a catalog endpoint for service '{}', filters {:?}",
-            service_type, filters
-        );
-        let token = self.cached_token(client).await?;
-        token.catalog.find_endpoint(&service_type, &filters)
+        let catalog = self.catalog.read().expect("Poisoned service catalog lock");
+        catalog.find_endpoint(service_type, filters)
     }
 
     /// Get the authentication token string.
@@ -163,7 +157,13 @@ impl Internal {
             .json(&self.body)
             .send()
             .await?;
-        *lock = Some(token_from_response(client::check(resp).await?).await?);
+        let (token, catalog) = token_from_response(client::check(resp).await?).await?;
+        *lock = Some(token);
+
+        // We're using a secondary lock here because catalog is accessed in non-async context too
+        let mut catalog_lock = self.catalog.write().expect("Poisoned service catalog lock");
+        *catalog_lock = catalog;
+
         Ok(())
     }
 
@@ -183,16 +183,6 @@ impl Internal {
     }
 }
 
-impl Clone for Internal {
-    fn clone(&self) -> Internal {
-        Internal {
-            body: self.body.clone(),
-            token_endpoint: self.token_endpoint.clone(),
-            cached_token: RwLock::new(None),
-        }
-    }
-}
-
 #[inline]
 fn token_alive(token: &impl Deref<Target = Option<Token>>) -> bool {
     if let Some(value) = token.deref() {
@@ -204,7 +194,7 @@ fn token_alive(token: &impl Deref<Target = Option<Token>>) -> bool {
     }
 }
 
-async fn token_from_response(resp: Response) -> Result<Token, Error> {
+async fn token_from_response(resp: Response) -> Result<(Token, ServiceCatalog), Error> {
     let value = match resp.headers().get("x-subject-token") {
         Some(hdr) => match hdr.to_str() {
             Ok(s) => Ok(s.to_string()),
@@ -233,9 +223,11 @@ async fn token_from_response(resp: Response) -> Result<Token, Error> {
     let root = resp.json::<protocol::TokenRoot>().await?;
     debug!("Received a token expiring at {}", root.token.expires_at);
     trace!("Received catalog: {:?}", root.token.catalog);
-    Ok(Token {
-        value,
-        expires_at: root.token.expires_at,
-        catalog: ServiceCatalog::new(root.token.catalog),
-    })
+    Ok((
+        Token {
+            value,
+            expires_at: root.token.expires_at,
+        },
+        ServiceCatalog::new(root.token.catalog),
+    ))
 }

--- a/src/identity/password.rs
+++ b/src/identity/password.rs
@@ -87,8 +87,7 @@ use crate::{AuthType, EndpointFilters, Error};
 ///
 /// The authentication token is cached while it's still valid or until
 /// [refresh](../trait.AuthType.html#tymethod.refresh) is called.
-/// Clones of a `Password` also start with an empty cache.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Password {
     inner: Internal,
 }
@@ -189,13 +188,8 @@ impl AuthType for Password {
     }
 
     /// Get a URL for the requested service.
-    async fn get_endpoint(
-        &self,
-        client: &Client,
-        service_type: String,
-        filters: EndpointFilters,
-    ) -> Result<Url, Error> {
-        self.inner.get_endpoint(client, service_type, filters).await
+    fn get_endpoint(&self, service_type: &str, filters: &EndpointFilters) -> Result<Url, Error> {
+        self.inner.get_endpoint(service_type, filters)
     }
 
     /// Refresh the cached token and service catalog.

--- a/src/identity/token.rs
+++ b/src/identity/token.rs
@@ -50,7 +50,7 @@ use crate::{AuthType, EndpointFilters, Error};
 /// The authentication token is cached while it's still valid or until
 /// [refresh](../trait.AuthType.html#tymethod.refresh) is called.
 /// Clones of a `Token` also start with an empty cache.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Token {
     inner: Internal,
 }
@@ -133,13 +133,8 @@ impl AuthType for Token {
     }
 
     /// Get a URL for the requested service.
-    async fn get_endpoint(
-        &self,
-        client: &Client,
-        service_type: String,
-        filters: EndpointFilters,
-    ) -> Result<Url, Error> {
-        self.inner.get_endpoint(client, service_type, filters).await
+    fn get_endpoint(&self, service_type: &str, filters: &EndpointFilters) -> Result<Url, Error> {
+        self.inner.get_endpoint(service_type, filters)
     }
 
     /// Refresh the cached token and service catalog.

--- a/src/loading/cloud.rs
+++ b/src/loading/cloud.rs
@@ -431,8 +431,8 @@ mod test_cloud_config {
         assert!(cfg.create_session_config().is_err());
     }
 
-    #[tokio::test]
-    async fn test_create_session_config_none_auth() {
+    #[test]
+    fn test_create_session_config_none_auth() {
         let options = hashmap! {
             "baremetal_endpoint_override".into() => "http://127.0.0.1/baremetal".into(),
         };
@@ -444,13 +444,12 @@ mod test_cloud_config {
         let sscfg = cfg.create_session_config().unwrap();
         assert!(sscfg
             .client
-            .get_endpoint("baremetal".into(), Default::default())
-            .await
+            .get_endpoint("baremetal", &Default::default())
             .is_err());
     }
 
-    #[tokio::test]
-    async fn test_create_session_config_basic_auth() {
+    #[test]
+    fn test_create_session_config_basic_auth() {
         let cfg = CloudConfig {
             auth_type: Some("http_basic".into()),
             auth: Some(Auth {
@@ -465,8 +464,7 @@ mod test_cloud_config {
         assert_eq!(
             sscfg
                 .client
-                .get_endpoint("baremetal".into(), Default::default())
-                .await
+                .get_endpoint("baremetal", &Default::default())
                 .unwrap()
                 .as_str(),
             "http://127.0.0.1/"

--- a/src/session.rs
+++ b/src/session.rs
@@ -716,11 +716,9 @@ impl Session {
         } else {
             let ep = match self.endpoint_overrides.get(catalog_type) {
                 Some(found) => found.clone(),
-                None => {
-                    self.client
-                        .get_endpoint(catalog_type.to_string(), self.endpoint_filters.clone())
-                        .await?
-                }
+                None => self
+                    .client
+                    .get_endpoint(catalog_type, &self.endpoint_filters)?,
             };
             let info = ServiceInfo::fetch(service, ep, &self.client).await?;
             let value = filter(&info);


### PR DESCRIPTION
BREAKING CHANGE

Modifies the signature of `AuthType.get_endpoint`.