### PR TITLE
feat: start requests synchronously, authenticate later

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -17,10 +17,9 @@
 use std::fmt::Debug;
 
 use async_trait::async_trait;
-use reqwest::{Client, Url};
+use reqwest::{Client, RequestBuilder, Url};
 use static_assertions::{assert_impl_all, assert_obj_safe};
 
-use super::client::RequestBuilder;
 use super::{EndpointFilters, Error, ErrorKind};
 
 /// Trait for an authentication type.

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -15,10 +15,9 @@
 //! HTTP basic authentication.
 
 use async_trait::async_trait;
-use reqwest::{Client, Url};
+use reqwest::{Client, RequestBuilder, Url};
 use static_assertions::assert_impl_all;
 
-use super::client::RequestBuilder;
 use super::{AuthType, EndpointFilters, Error, ErrorKind};
 
 /// Authentication type that uses HTTP basic authentication.
@@ -68,7 +67,7 @@ impl AuthType for BasicAuth {
         _client: &Client,
         request: RequestBuilder,
     ) -> Result<RequestBuilder, Error> {
-        Ok(request.basic_auth(&self.username, &self.password))
+        Ok(request.basic_auth(&self.username, Some(&self.password)))
     }
 
     /// Get a predefined endpoint for all service types

--- a/src/identity/internal.rs
+++ b/src/identity/internal.rs
@@ -21,13 +21,13 @@ use std::{collections::hash_map::DefaultHasher, sync::RwLock};
 
 use chrono::{DateTime, Duration, FixedOffset, Local};
 use log::{debug, error, trace};
-use reqwest::{Client, Response, Url};
+use reqwest::{Client, RequestBuilder, Response, Url};
 use tokio::sync::{RwLock as AsyncRwLock, RwLockReadGuard};
 
 use super::protocol::{self, AuthRoot};
 use super::{IdOrName, Scope, INVALID_SUBJECT_HEADER, MISSING_SUBJECT_HEADER, TOKEN_MIN_VALIDITY};
 use crate::catalog::ServiceCatalog;
-use crate::client::{self, RequestBuilder};
+use crate::client;
 use crate::{EndpointFilters, Error, ErrorKind};
 
 /// Plain authentication token without additional details.

--- a/src/identity/password.rs
+++ b/src/identity/password.rs
@@ -15,13 +15,12 @@
 //! Password authentication.
 
 use async_trait::async_trait;
-use reqwest::{Client, Url};
+use reqwest::{Client, RequestBuilder, Url};
 use static_assertions::assert_impl_all;
 
 use super::internal::Internal;
 use super::protocol;
 use super::Scope;
-use crate::client::RequestBuilder;
 use crate::common::IdOrName;
 use crate::{AuthType, EndpointFilters, Error};
 

--- a/src/identity/token.rs
+++ b/src/identity/token.rs
@@ -15,13 +15,12 @@
 //! Token authentication.
 
 use async_trait::async_trait;
-use reqwest::{Client, Url};
+use reqwest::{Client, RequestBuilder, Url};
 use static_assertions::assert_impl_all;
 
 use super::internal::Internal;
 use super::protocol;
 use super::{IdOrName, Scope};
-use crate::client::RequestBuilder;
 use crate::{AuthType, EndpointFilters, Error};
 
 /// Token authentication using Identity API V3.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -155,11 +155,7 @@ async fn fetch_root(
     client: &AuthenticatedClient,
 ) -> Result<Root, Error> {
     debug!("Fetching {} service info from {}", catalog_type, endpoint);
-    client
-        .request(Method::GET, endpoint)
-        .await?
-        .fetch_json()
-        .await
+    client.request(Method::GET, endpoint).fetch_json().await
 }
 
 impl ServiceInfo {

--- a/src/session.rs
+++ b/src/session.rs
@@ -488,7 +488,7 @@ impl Session {
             url,
             api_version
         );
-        let mut builder = self.client.request(method, url).await?;
+        let mut builder = self.client.request(method, url);
         if let Some(version) = api_version {
             let mut headers = HeaderMap::new();
             service.set_api_version_headers(&mut headers, version)?;


### PR DESCRIPTION
BREAKING CHANGE

Starting requests is no longer an asynchronous action.