### PR TITLE
Revert "feat(auth): make get_endpoint synchronous"

### DIFF
--- a/src/basic.rs
+++ b/src/basic.rs
@@ -71,7 +71,12 @@ impl AuthType for BasicAuth {
     }
 
     /// Get a predefined endpoint for all service types
-    fn get_endpoint(&self, _service_type: &str, _filters: &EndpointFilters) -> Result<Url, Error> {
+    async fn get_endpoint(
+        &self,
+        _client: &Client,
+        _service_type: String,
+        _filters: EndpointFilters,
+    ) -> Result<Url, Error> {
         Ok(self.endpoint.clone())
     }
 

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -33,10 +33,6 @@ impl ServiceCatalog {
         ServiceCatalog { inner: catalog }
     }
 
-    pub(crate) fn empty() -> ServiceCatalog {
-        ServiceCatalog { inner: Vec::new() }
-    }
-
     /// Find an endpoint in the catalog.
     pub fn find_endpoint(
         &self,

--- a/src/client.rs
+++ b/src/client.rs
@@ -102,12 +102,14 @@ impl AuthenticatedClient {
 
     /// Get a URL for the requested service.
     #[inline]
-    pub fn get_endpoint(
+    pub async fn get_endpoint(
         &self,
-        service_type: &str,
-        filters: &EndpointFilters,
+        service_type: String,
+        filters: EndpointFilters,
     ) -> Result<Url, Error> {
-        self.auth.get_endpoint(service_type, filters)
+        self.auth
+            .get_endpoint(&self.client, service_type, filters)
+            .await
     }
 
     /// Get a reference to the inner (non-authenticated) client.

--- a/src/identity/password.rs
+++ b/src/identity/password.rs
@@ -86,7 +86,8 @@ use crate::{AuthType, EndpointFilters, Error};
 ///
 /// The authentication token is cached while it's still valid or until
 /// [refresh](../trait.AuthType.html#tymethod.refresh) is called.
-#[derive(Debug)]
+/// Clones of a `Password` also start with an empty cache.
+#[derive(Debug, Clone)]
 pub struct Password {
     inner: Internal,
 }
@@ -187,8 +188,13 @@ impl AuthType for Password {
     }
 
     /// Get a URL for the requested service.
-    fn get_endpoint(&self, service_type: &str, filters: &EndpointFilters) -> Result<Url, Error> {
-        self.inner.get_endpoint(service_type, filters)
+    async fn get_endpoint(
+        &self,
+        client: &Client,
+        service_type: String,
+        filters: EndpointFilters,
+    ) -> Result<Url, Error> {
+        self.inner.get_endpoint(client, service_type, filters).await
     }
 
     /// Refresh the cached token and service catalog.

--- a/src/identity/token.rs
+++ b/src/identity/token.rs
@@ -49,7 +49,7 @@ use crate::{AuthType, EndpointFilters, Error};
 /// The authentication token is cached while it's still valid or until
 /// [refresh](../trait.AuthType.html#tymethod.refresh) is called.
 /// Clones of a `Token` also start with an empty cache.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Token {
     inner: Internal,
 }
@@ -132,8 +132,13 @@ impl AuthType for Token {
     }
 
     /// Get a URL for the requested service.
-    fn get_endpoint(&self, service_type: &str, filters: &EndpointFilters) -> Result<Url, Error> {
-        self.inner.get_endpoint(service_type, filters)
+    async fn get_endpoint(
+        &self,
+        client: &Client,
+        service_type: String,
+        filters: EndpointFilters,
+    ) -> Result<Url, Error> {
+        self.inner.get_endpoint(client, service_type, filters).await
     }
 
     /// Refresh the cached token and service catalog.

--- a/src/loading/cloud.rs
+++ b/src/loading/cloud.rs
@@ -431,8 +431,8 @@ mod test_cloud_config {
         assert!(cfg.create_session_config().is_err());
     }
 
-    #[test]
-    fn test_create_session_config_none_auth() {
+    #[tokio::test]
+    async fn test_create_session_config_none_auth() {
         let options = hashmap! {
             "baremetal_endpoint_override".into() => "http://127.0.0.1/baremetal".into(),
         };
@@ -444,12 +444,13 @@ mod test_cloud_config {
         let sscfg = cfg.create_session_config().unwrap();
         assert!(sscfg
             .client
-            .get_endpoint("baremetal", &Default::default())
+            .get_endpoint("baremetal".into(), Default::default())
+            .await
             .is_err());
     }
 
-    #[test]
-    fn test_create_session_config_basic_auth() {
+    #[tokio::test]
+    async fn test_create_session_config_basic_auth() {
         let cfg = CloudConfig {
             auth_type: Some("http_basic".into()),
             auth: Some(Auth {
@@ -464,7 +465,8 @@ mod test_cloud_config {
         assert_eq!(
             sscfg
                 .client
-                .get_endpoint("baremetal", &Default::default())
+                .get_endpoint("baremetal".into(), Default::default())
+                .await
                 .unwrap()
                 .as_str(),
             "http://127.0.0.1/"

--- a/src/session.rs
+++ b/src/session.rs
@@ -673,9 +673,11 @@ impl Session {
         } else {
             let ep = match self.endpoint_overrides.get(catalog_type) {
                 Some(found) => found.clone(),
-                None => self
-                    .client
-                    .get_endpoint(catalog_type, &self.endpoint_filters)?,
+                None => {
+                    self.client
+                        .get_endpoint(catalog_type.to_string(), self.endpoint_filters.clone())
+                        .await?
+                }
             };
             let info = ServiceInfo::fetch(service, ep, &self.client).await?;
             let value = filter(&info);


### PR DESCRIPTION
The original idea does not work out, so this is unnecessary
overcomplication.

This reverts commit 16a1d94b32da3c931905d163ec9a1bbfcdd3cf11.