### PR TITLE
Expose `PaginatedResource` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ mod protocol;
 pub mod services;
 mod session;
 #[cfg(feature = "stream")]
-mod stream;
+pub mod stream;
 mod url;
 mod utils;
 


### PR DESCRIPTION
Hi,

This PR is made in the context of my other PR ([**#131**]) for `rust-openstack` which aims to move the entire SDK to `async/await`.  

[**#131**]: https://github.com/dtantsur/rust-openstack/pull/131

In this endeavour, the SDK needs to be able to implement `PaginatedResource` on some of its type to allow the use of the `ServiceRequestBuilder::fetch_paginated` method.

Previously, the `stream` feature would publicly expose `fetch_paginated`, but not the trait (`PaginatedResource`) needed to make use of it, which remained private due to the `stream` module not marked as `pub`.  

This PR simply adds the missing `pub` keyword to the `stream` module declaration, making `PaginatedResource` publicly accessible (still under the `stream` feature).  

`PaginatedResource` is the only item to become publicly exposed after this change, so I thought that this would be the way to go.  