### PR TITLE
fix: fix double percent-encoding on URLs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ http = "^0.2"
 lazy_static = "^1.4"
 log = "^0.4"
 osauth-derive = { version = "^0.1", optional = true }
+percent-encoding = "^2.2"
 pin-project = "^1.0"
 reqwest = { version = "^0.11", default-features = false, features = ["gzip", "json", "stream"] }
 serde = { version = "^1.0", features = ["derive"] }

--- a/src/url.rs
+++ b/src/url.rs
@@ -170,13 +170,13 @@ mod test {
     }
 
     #[test]
-    fn test_merge_with_percent_encoding() {
-        let mut dest = Url::parse("http://compute/path%2Fto%2Ffoo%20bar").unwrap();
+    fn test_merge_with_percent_encoded_segments() {
+        let mut dest = Url::parse("http://compute/path%2Fto/foo%20bar").unwrap();
         let src = Url::parse("https://example.com:5050/compute/").unwrap();
         merge(&mut dest, &src);
         assert_eq!(
             dest.as_str(),
-            "https://example.com:5050/compute/path%2Fto%2Ffoo%20bar"
+            "https://example.com:5050/compute/path%2Fto/foo%20bar"
         );
     }
 }

--- a/src/url.rs
+++ b/src/url.rs
@@ -53,7 +53,15 @@ pub fn merge(dest: &mut Url, src: &Url) {
     dest.set_scheme(src.scheme()).unwrap();
     dest.set_host(src.host_str()).unwrap();
     dest.set_port(src.port()).unwrap();
-    let existing: Vec<String> = dest.path_segments().unwrap().map(str::to_string).collect();
+    let existing: Vec<String> = dest
+        .path_segments()
+        .unwrap()
+        .map(|segment| {
+            percent_encoding::percent_decode_str(segment)
+                .decode_utf8_lossy()
+                .into_owned()
+        })
+        .collect();
     dest.path_segments_mut()
         .unwrap()
         .clear()
@@ -158,6 +166,17 @@ mod test {
         assert_eq!(
             dest.as_str(),
             "https://example.com:5050/compute/path/1/?foo=bar,answer=42"
+        );
+    }
+
+    #[test]
+    fn test_merge_with_percent_encoding() {
+        let mut dest = Url::parse("http://compute/path%2Fto%2Ffoo%20bar").unwrap();
+        let src = Url::parse("https://example.com:5050/compute/").unwrap();
+        merge(&mut dest, &src);
+        assert_eq!(
+            dest.as_str(),
+            "https://example.com:5050/compute/path%2Fto%2Ffoo%20bar"
         );
     }
 }


### PR DESCRIPTION
While using the `object-storage` feature in `rust-openstack`, I noticed that some requests I was doing were unexpectedly failing, like retrieving the metadata for an object that I knew existed.  

Enabling logs revealed the problem that `Session` does mistakenly percent-encode its path-segments twice before sending the request.

Digging a bit more, I found that it was due to how URLs are constructed in `Session`.

The SDK calls `Session::request`, which construct an initial URL with a dummy origin, to be replaced later on:
https://github.com/dtantsur/rust-osauth/blob/8dd97a0004b8b0ee49c767fef572e708b1ad2361/src/session.rs#L465-L469

That first step calls `crate::url::extend` which causes its path-segments to be percent-encoded once (by calling `PathSegmentsMut::extend`):
https://github.com/dtantsur/rust-osauth/blob/8dd97a0004b8b0ee49c767fef572e708b1ad2361/src/url.rs#L32-L35

Later, the SDK calls `ServiceRequestBuilder::send`, which calls `ServiceRequestBuilder::send_unchecked`, which calls `RequestBuilder::send_unchecked_to`, which constructs the final URL by replacing the dummy origin by the one that corresponds to the service we're calling (using `crate::url::merge`):
https://github.com/dtantsur/rust-osauth/blob/8dd97a0004b8b0ee49c767fef572e708b1ad2361/src/client.rs#L329

This step attempts to prepend the desired URL path segments with the service endpoint's path segments, like so:
https://github.com/dtantsur/rust-osauth/blob/8dd97a0004b8b0ee49c767fef572e708b1ad2361/src/url.rs#L56-L62

But the issue is that this calls `PathSegmentsMut::extend` again, which does percent-encoding again on the path segments, while the `PathSegments` iterator that we used to collect them does not undo the first percent-encoding that we did for the dummy URL, resulting in a doubly percent-encoded URL, which any request that depends on percent-encoding to fail.

So here is a fix which adds the `percent-encoding` crate as a dependency and changes `crate::url::merge` to undo the percent-encoding when collecting the path segments before re-encoding them again in the final URL.  
A new regression test, which did fail before this fix, is added as well.

Before creating this PR, having read the comment in `Session::request`, I tried to look at ways to fix this by changing how the URLs gets handled and constructed, but I didn't find anything substantially better than how it's done right now.