### PR TITLE
Add support for Application Credential authentication

### DIFF
--- a/src/identity/application_credential.rs
+++ b/src/identity/application_credential.rs
@@ -1,0 +1,161 @@
+// Copyright 2023 Matt Williams <matt@milliams.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Application Credential authentication.
+
+use async_trait::async_trait;
+use reqwest::{Client, RequestBuilder, Url};
+use static_assertions::assert_impl_all;
+
+use super::internal::Internal;
+use super::protocol;
+use super::IdOrName;
+use crate::{AuthType, EndpointFilters, Error};
+
+/// Application Credential authentication using Identity API V3.
+///
+/// For any Identity authentication you need to know `auth_url`, which is an authentication endpoint
+/// of the Identity service. For the Application Credential authentication you also need:
+/// 1. Application Credential ID
+/// 2. Application Credential secret
+///
+/// Start with creating a `ApplicationCredential` object using [new](#method.new):
+///
+/// ```rust,no_run
+/// use osauth::common::IdOrName;
+/// let auth = osauth::identity::ApplicationCredential::new(
+///     "https://cloud.local/identity",
+///     "<a cred id>",
+///     "<a cred secret>",
+/// )
+/// .expect("Invalid auth_url");
+///
+/// let session = osauth::Session::new(auth);
+/// ```
+///
+/// The authentication token is cached while it's still valid or until
+/// [refresh](../trait.AuthType.html#tymethod.refresh) is called.
+/// Clones of an `ApplicationCredential` also start with an empty cache.
+#[derive(Debug, Clone)]
+pub struct ApplicationCredential {
+    inner: Internal,
+}
+
+assert_impl_all!(ApplicationCredential: Send, Sync);
+
+impl ApplicationCredential {
+    /// Create an application credential authentication.
+    pub fn new<U, S1, S2>(auth_url: U, id: S1, secret: S2) -> Result<Self, Error>
+    where
+        U: AsRef<str>,
+        S1: Into<String>,
+        S2: Into<String>,
+    {
+        let app_cred = protocol::ApplicationCredential {
+            id: IdOrName::Id(id.into()),
+            secret: secret.into(),
+            user: None,
+        };
+        let body = protocol::AuthRoot {
+            auth: protocol::Auth {
+                identity: protocol::Identity::ApplicationCredential(app_cred),
+                scope: None,
+            },
+        };
+        Ok(Self {
+            inner: Internal::new(auth_url.as_ref(), body)?,
+        })
+    }
+
+    /// Create an application credential authentication from a credential name.
+    pub fn with_user_id<U, S1, S2, S3>(
+        auth_url: U,
+        name: S1,
+        secret: S2,
+        user_id: S3,
+    ) -> Result<Self, Error>
+    where
+        U: AsRef<str>,
+        S1: Into<String>,
+        S2: Into<String>,
+        S3: Into<String>,
+    {
+        let app_cred = protocol::ApplicationCredential {
+            id: IdOrName::Name(name.into()),
+            secret: secret.into(),
+            user: Some(IdOrName::Id(user_id.into())),
+        };
+        let body = protocol::AuthRoot {
+            auth: protocol::Auth {
+                identity: protocol::Identity::ApplicationCredential(app_cred),
+                scope: None,
+            },
+        };
+        Ok(Self {
+            inner: Internal::new(auth_url.as_ref(), body)?,
+        })
+    }
+
+    /// Project name or ID (if project scoped).
+    #[inline]
+    pub fn project(&self) -> Option<&IdOrName> {
+        self.inner.project()
+    }
+}
+
+#[async_trait]
+impl AuthType for ApplicationCredential {
+    /// Authenticate a request.
+    async fn authenticate(
+        &self,
+        client: &Client,
+        request: RequestBuilder,
+    ) -> Result<RequestBuilder, Error> {
+        self.inner.authenticate(client, request).await
+    }
+
+    /// Get a URL for the requested service.
+    async fn get_endpoint(
+        &self,
+        client: &Client,
+        service_type: &str,
+        filters: &EndpointFilters,
+    ) -> Result<Url, Error> {
+        self.inner.get_endpoint(client, service_type, filters).await
+    }
+
+    /// Refresh the cached token and service catalog.
+    async fn refresh(&self, client: &Client) -> Result<(), Error> {
+        self.inner.refresh(client, true).await
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    #![allow(unused_results)]
+
+    use reqwest::Url;
+
+    use super::ApplicationCredential;
+
+    #[test]
+    fn test_identity_new() {
+        let id = ApplicationCredential::new("http://127.0.0.1:8080/", "abcdef", "shhhh").unwrap();
+        let e = Url::parse(id.inner.token_endpoint()).unwrap();
+        assert_eq!(e.scheme(), "http");
+        assert_eq!(e.host_str().unwrap(), "127.0.0.1");
+        assert_eq!(e.port().unwrap(), 8080u16);
+        assert_eq!(e.path(), "/v3/auth/tokens");
+    }
+}

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -14,7 +14,7 @@
 
 //! Authentication using Identity API v3.
 //!
-//! Currently only supports [Password](struct.Password.html) authentication.
+//! Currently supports [Password](struct.Password.html) and [ApplicationCredential] authentication.
 //! Identity API v2 is not and will not be supported.
 
 mod application_credential;

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -17,6 +17,7 @@
 //! Currently only supports [Password](struct.Password.html) authentication.
 //! Identity API v2 is not and will not be supported.
 
+mod application_credential;
 mod internal;
 mod password;
 pub(crate) mod protocol;
@@ -24,6 +25,7 @@ mod token;
 
 use super::common::IdOrName;
 
+pub use self::application_credential::ApplicationCredential;
 pub use self::password::Password;
 pub use self::token::Token;
 

--- a/src/loading/cloud.rs
+++ b/src/loading/cloud.rs
@@ -26,7 +26,7 @@ use super::config::from_config;
 use super::env::from_env;
 use crate::client::AuthenticatedClient;
 use crate::common::IdOrName;
-use crate::identity::{Password, Scope, Token};
+use crate::identity::{ApplicationCredential, Password, Scope, Token};
 use crate::{AuthType, BasicAuth, Error, ErrorKind, InterfaceType, NoAuth, Session};
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -54,6 +54,12 @@ pub(crate) struct Auth {
     pub(crate) user_domain_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) user_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) application_credential_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) application_credential_secret: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) application_credential_name: Option<String>,
 }
 
 /// Cloud configuration.
@@ -171,6 +177,38 @@ impl Auth {
         Ok(id)
     }
 
+    fn create_application_credential(self) -> Result<ApplicationCredential, Error> {
+        let auth_url = require(
+            self.auth_url,
+            "Password authentication requires an authentication URL",
+        )?;
+        let app_secret = require(
+            self.application_credential_secret,
+            "Application credential requires a secret",
+        )?;
+
+        if let Some(app_id) = self.application_credential_id {
+            ApplicationCredential::new(auth_url, app_id, app_secret)
+        } else if let Some(app_name) = self.application_credential_name {
+            if self.username.is_some() && self.user_id.is_none() {
+                return Err(Error::new(
+                    ErrorKind::InvalidConfig,
+                    "Specifying Application Credential by name currently requires specifying the user ID",
+                ));
+            }
+            let user_id = require(
+                self.user_id,
+                "Application Credential authentication by name requires the user ID",
+            )?;
+            ApplicationCredential::with_user_id(auth_url, app_name, app_secret, user_id)
+        } else {
+            Err(Error::new(
+                ErrorKind::InvalidConfig,
+                "Application Credential requires an id or a name",
+            ))
+        }
+    }
+
     fn create_auth(self, auth_type: Option<String>) -> Result<Arc<dyn AuthType>, Error> {
         let auth_type = auth_type.unwrap_or_else(|| {
             if self.token.is_some() {
@@ -187,6 +225,8 @@ impl Auth {
             Arc::new(self.create_token_auth()?)
         } else if auth_type == "http_basic" {
             Arc::new(self.create_basic_auth()?)
+        } else if auth_type == "v3applicationcredential" {
+            Arc::new(self.create_application_credential()?)
         } else if auth_type == "none" {
             Arc::new(self.create_none_auth()?)
         } else {

--- a/src/loading/cloud.rs
+++ b/src/loading/cloud.rs
@@ -52,6 +52,8 @@ pub(crate) struct Auth {
     pub(crate) username: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) user_domain_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) user_id: Option<String>,
 }
 
 /// Cloud configuration.

--- a/src/loading/config.rs
+++ b/src/loading/config.rs
@@ -386,6 +386,30 @@ hK9jLBzNvo8qzKqaGfnGieuLeXCqFDA=
     }
 
     #[test]
+    fn test_from_config_application_credential() {
+        let clouds = to_yaml(
+            r#"clouds:
+  cloud_name:
+    auth_type: v3applicationcredential
+    auth:
+      auth_url: http://url1
+      application_credential_id: appid1
+      application_credential_secret: appidsecret1
+    region_name: region1"#,
+        );
+
+        let _ = from_files(
+            "cloud_name",
+            clouds,
+            with_one_key("public-clouds"),
+            with_one_key("clouds"),
+        )
+        .unwrap()
+        .create_session_config()
+        .unwrap();
+    }
+
+    #[test]
     fn test_inject_profiles_error() {
         let mut clouds_data = to_yaml(
             r#"

--- a/src/loading/env.rs
+++ b/src/loading/env.rs
@@ -50,6 +50,7 @@ fn _from_env<E: Environment>(env: E) -> Result<CloudConfig, Error> {
         token: env.get("OS_TOKEN").ok(),
         username: env.get("OS_USERNAME").ok(),
         user_domain_name: env.get("OS_USER_DOMAIN_NAME").ok(),
+        user_id: env.get("OS_USER_ID").ok(),
     };
 
     let config = CloudConfig {

--- a/src/loading/env.rs
+++ b/src/loading/env.rs
@@ -51,6 +51,9 @@ fn _from_env<E: Environment>(env: E) -> Result<CloudConfig, Error> {
         username: env.get("OS_USERNAME").ok(),
         user_domain_name: env.get("OS_USER_DOMAIN_NAME").ok(),
         user_id: env.get("OS_USER_ID").ok(),
+        application_credential_id: env.get("OS_APPLICATION_CREDENTIAL_ID").ok(),
+        application_credential_secret: env.get("OS_APPLICATION_CREDENTIAL_SECRET").ok(),
+        application_credential_name: env.get("OS_APPLICATION_CREDENTIAL_NAME").ok(),
     };
 
     let config = CloudConfig {


### PR DESCRIPTION
This adds support for [Application Credential authentication](https://docs.openstack.org/api-ref/identity/v3/?expanded=authenticating-with-an-application-credential-detail#application-credentials).

It supports passing the application credential by ID (`application_credential_id`/`OS_APPLICATION_CREDENTIAL_ID` -- the default OpenStack RC and clouds.yaml format), or specifying the credential by name (`application_credential_name`/`OS_APPLICATION_CREDENTIAL_NAME`) if the user ID (`user_id`/`OS_USER_ID`) is also set.

It doesn't currently support setting the application credential by name and also relying on the `username` (as that requires setting domains etc.) but that can always be added in later.

I have tested this against a live OpenStack Yoga cluster.